### PR TITLE
Change Support with Contact and Support

### DIFF
--- a/public/nav-config.json
+++ b/public/nav-config.json
@@ -162,7 +162,7 @@
           {
             "type": "link",
             "settings": {
-              "name": "Support",
+              "name": "Contact and Support",
               "href": "/resources/support",
               "activeTest": "/resources/support"
             }


### PR DESCRIPTION
This is a proposed fix for https://github.com/qgis/QGIS-Website/issues/451

- Change the "Support" menu entry to "Contact and Support" as the page content contains QGIS' channels links

![image](https://github.com/user-attachments/assets/394357b5-b2b4-479b-a0fb-eb042928223a)
